### PR TITLE
Upgrade PHPStan and PHP-CS-Fixer

### DIFF
--- a/.cs.php
+++ b/.cs.php
@@ -8,7 +8,7 @@ return (new PhpCsFixer\Config())
             '@PSR1' => true,
             '@PSR2' => true,
             '@Symfony' => true,
-            'psr4' => true,
+            'psr_autoloading' => true,
             // custom rules
             'align_multiline_comment' => ['comment_type' => 'phpdocs_only'], // psr-5
             'phpdoc_to_comment' => false,
@@ -21,7 +21,7 @@ return (new PhpCsFixer\Config())
             'declare_equal_normalize' => ['space' => 'single'],
             'increment_style' => ['style' => 'post'],
             'list_syntax' => ['syntax' => 'short'],
-            'no_short_echo_tag' => true,
+            'echo_tag_syntax' => ['format' => 'long'],
             'phpdoc_add_missing_param_annotation' => ['only_untyped' => false],
             'phpdoc_align' => false,
             'phpdoc_no_empty_return' => false,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.4', '8.0', '8.1' ]
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ responses and many other things.
 
 ## Requirements
 
-* PHP 7.2+ or 8.0+
+* PHP 7.4+ or 8.0+
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     "homepage": "https://github.com/selective-php/transformer",
     "license": "MIT",
     "require": {
-        "php": "^7.2 || ^8.0"
+        "php": "^7.4 || ^8.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.16",
+        "friendsofphp/php-cs-fixer": "^3",
         "overtrue/phplint": "^2.3",
-        "phpstan/phpstan": "0.*",
+        "phpstan/phpstan": "^1",
         "phpunit/phpunit": "^8 || ^9",
         "squizlabs/php_codesniffer": "^3.5"
     },
@@ -46,7 +46,7 @@
             "@phpstan",
             "@test:coverage"
         ],
-        "cs:check": "php-cs-fixer fix --dry-run --format=txt --verbose --diff --diff-format=udiff --config=.cs.php",
+        "cs:check": "php-cs-fixer fix --dry-run --format=txt --verbose --diff --config=.cs.php",
         "cs:fix": "php-cs-fixer fix --config=.cs.php",
         "lint": "phplint ./ --exclude=vendor --no-interaction --no-cache",
         "phpstan": "phpstan analyse src --level=max -c phpstan.neon --no-progress --ansi",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,13 @@
 parameters:
-	checkMissingIterableValueType: false
+	reportUnmatchedIgnoredErrors: false
+	ignoreErrors:
+		- '#Parameter \#2 \$default of method Selective\\Transformer\\ArrayData::get\(\) expects null, mixed given.#'
+		- '#Parameter \#2 \$filter of method Selective\\Transformer\\ArrayTransformer::registerFilter\(\) expects callable\(\): mixed, object given.#'
+		- '#Parameter \#2 \$code of class Selective\\Transformer\\Exceptions\\ArrayTransformerException constructor expects int, mixed given.#'
+		- '#Parameter \#1 \$datetime of class DateTimeImmutable constructor expects string, mixed given.#'
+		- '#Parameter \#1 \$number of function number_format expects float, mixed given.#'
+		- '#Parameter \#1 \$source of method Selective\\Transformer\\ArrayTransformer::toArray\(\) expects array, mixed given.#'
+		- '#Parameter \#2 ...\$values of function sprintf expects bool\|float\|int\|string\|null, mixed given.#'
+		- '#Parameter \#1 \$num of function number_format expects float, mixed given.#'
+		- "#Cannot cast mixed#"
+		- "#Cannot access offset#"

--- a/src/ArrayData.php
+++ b/src/ArrayData.php
@@ -12,14 +12,14 @@ final class ArrayData
     /**
      * Internal representation of data data.
      *
-     * @var array
+     * @var array<mixed>
      */
     private $data;
 
     /**
      * The constructor.
      *
-     * @param array $data The data
+     * @param array<mixed> $data The data
      */
     public function __construct(array $data = [])
     {
@@ -58,7 +58,7 @@ final class ArrayData
      *
      * @param string $path The path
      *
-     * @return string[] The key paths
+     * @return array<string> The key paths
      */
     private function keyToPathArray(string $path): array
     {
@@ -97,7 +97,7 @@ final class ArrayData
     /**
      * Get all values.
      *
-     * @return array The values
+     * @return array<mixed> The values
      */
     public function all(): array
     {

--- a/src/ArrayTransformer.php
+++ b/src/ArrayTransformer.php
@@ -145,10 +145,10 @@ final class ArrayTransformer implements TransformerInterface
     /**
      * Transform list of arrays to list of arrays.
      *
-     * @param array $source The source
-     * @param array $target The target (optional)
+     * @param array<mixed> $source The source
+     * @param array<mixed> $target The target (optional)
      *
-     * @return array The result
+     * @return array<mixed> The result
      */
     public function toArrays(array $source, array $target = []): array
     {
@@ -162,10 +162,10 @@ final class ArrayTransformer implements TransformerInterface
     /**
      * Transform array to array.
      *
-     * @param array $source The source
-     * @param array $target The target (optional)
+     * @param array<mixed> $source The source
+     * @param array<mixed> $target The target (optional)
      *
-     * @return array The result
+     * @return array<mixed> The result
      */
     public function toArray(array $source, array $target = []): array
     {

--- a/src/ArrayTransformerFilterItem.php
+++ b/src/ArrayTransformerFilterItem.php
@@ -13,7 +13,7 @@ final class ArrayTransformerFilterItem
     private $name;
 
     /**
-     * @var array
+     * @var array<mixed>
      */
     private $arguments;
 
@@ -21,7 +21,7 @@ final class ArrayTransformerFilterItem
      * The constructor.
      *
      * @param string $name The filter to apply
-     * @param array $arguments The parameters for the filter
+     * @param array<mixed> $arguments The parameters for the filter
      */
     public function __construct(string $name, array $arguments = [])
     {
@@ -42,7 +42,7 @@ final class ArrayTransformerFilterItem
     /**
      * Get filter parameters.
      *
-     * @return array The params
+     * @return array<mixed> The params
      */
     public function getArguments(): array
     {

--- a/src/ArrayValueConverter.php
+++ b/src/ArrayValueConverter.php
@@ -46,7 +46,7 @@ final class ArrayValueConverter
      *
      * @param string $name The filter name
      * @param mixed $value The value for the filter
-     * @param array $parameters The filter arguments (optional)
+     * @param array<mixed> $parameters The filter arguments (optional)
      *
      * @return mixed The filter result
      */

--- a/src/Filter/ArrayFilter.php
+++ b/src/Filter/ArrayFilter.php
@@ -12,7 +12,7 @@ final class ArrayFilter
      *
      * @param mixed $value The value
      *
-     * @return array The value
+     * @return array<mixed> The value
      */
     public function __invoke($value)
     {

--- a/src/Filter/TransformFilter.php
+++ b/src/Filter/TransformFilter.php
@@ -12,10 +12,10 @@ final class TransformFilter
     /**
      * Invoke.
      *
-     * @param array $value The values
+     * @param array<mixed> $value The values
      * @param callable $callback The callback
      *
-     * @return array|null The value
+     * @return array<mixed>|null The value
      */
     public function __invoke(array $value, callable $callback)
     {

--- a/src/Filter/TransformListFilter.php
+++ b/src/Filter/TransformListFilter.php
@@ -12,10 +12,10 @@ final class TransformListFilter
     /**
      * Invoke.
      *
-     * @param array $values The values
+     * @param array<mixed> $values The values
      * @param callable $callback The callback
      *
-     * @return array|null The value
+     * @return array<int, array<mixed>>|null The value
      */
     public function __invoke(array $values, callable $callback)
     {

--- a/src/Interfaces/TransformerInterface.php
+++ b/src/Interfaces/TransformerInterface.php
@@ -10,10 +10,10 @@ interface TransformerInterface
     /**
      * Transform array to array.
      *
-     * @param array $source The source
-     * @param array $target The target (optional)
+     * @param array<mixed> $source The source
+     * @param array<mixed> $target The target (optional)
      *
-     * @return array The result
+     * @return array<mixed> The result
      */
     public function toArray(array $source, array $target = []): array;
 }


### PR DESCRIPTION
# Changed log

- Upgrading PHPStan to be `^1` version.
- Upgrading PHP-CS-Fixer to be `^3` version.
- Drop `PHP 7.2` and `PHP 7.3` version supports.