### PR TITLE
Add PHP 8.2 tests in GitHub action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-versions: [ '8.1' ]
+        php-versions: [ '8.1', '8.2' ]
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "homepage": "https://github.com/selective-php/transformer",
     "license": "MIT",
     "require": {
-        "php": "^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3",


### PR DESCRIPTION
# Changed log

- Add `PHP-8.0` and `PHP-8.2` versions test in the GitHub workflow action.