### PR TITLE
Fix nullable types for PHP 8.4

### DIFF
--- a/.cs.php
+++ b/.cs.php
@@ -19,7 +19,7 @@ return (new Config())
             'array_syntax' => ['syntax' => 'short'],
             'cast_spaces' => ['space' => 'none'],
             'concat_space' => ['spacing' => 'one'],
-            'compact_nullable_typehint' => true,
+            'compact_nullable_type_declaration' => true,
             'declare_equal_normalize' => ['space' => 'single'],
             'general_phpdoc_annotation_remove' => [
                 'annotations' => [
@@ -36,7 +36,11 @@ return (new Config())
             'phpdoc_order' => true, // psr-5
             'phpdoc_no_useless_inheritdoc' => false,
             'protected_to_private' => false,
-            'yoda_style' => false,
+            'yoda_style' => [
+                'equal' => false,
+                'identical' => false,
+                'less_and_greater' => false
+            ],
             'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
             'ordered_imports' => [
                 'sort_algorithm' => 'alpha',

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 odan
+Copyright (c) 2025 odan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ responses and many other things.
 
 ## Requirements
 
-* PHP 8.1+
+* PHP 8.1 - 8.4
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
     ],
     "homepage": "https://github.com/selective-php/transformer",
     "require": {
-        "php": "^8.1"
+        "php": "8.1.* || 8.2.* || 8.3.* || 8.4.*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3",
-        "phpstan/phpstan": "^1",
+        "phpstan/phpstan": "^1 || ^2",
         "phpunit/phpunit": "^10",
         "squizlabs/php_codesniffer": "^3"
     },
@@ -49,13 +49,16 @@
         "sniffer:check": "phpcs --standard=phpcs.xml",
         "sniffer:fix": "phpcbf --standard=phpcs.xml",
         "stan": "phpstan analyse -c phpstan.neon --no-progress --ansi",
-        "test": "phpunit --configuration phpunit.xml --do-not-cache-result --colors=always",
+        "test": "phpunit --configuration phpunit.xml --do-not-cache-result --colors=always --display-warnings --display-deprecations --no-coverage",
         "test:all": [
             "@cs:check",
             "@sniffer:check",
             "@stan",
             "@test"
         ],
-        "test:coverage": "php -d xdebug.mode=coverage -r \"require 'vendor/bin/phpunit';\" -- --configuration phpunit.xml --do-not-cache-result --colors=always --coverage-clover build/logs/clover.xml --coverage-html build/coverage"
+        "test:coverage": [
+            "@putenv XDEBUG_MODE=coverage",
+            "phpunit --configuration phpunit.xml --do-not-cache-result --colors=always --display-warnings --display-deprecations --coverage-clover build/coverage/clover.xml --coverage-html build/coverage --coverage-text"
+        ]
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,5 @@
 parameters:
 	level: 8
-	checkMissingIterableValueType: false
 	reportUnmatchedIgnoredErrors: false
 	ignoreErrors:
 		- '#Parameter \#2 \$default of method Selective\\Transformer\\ArrayData::get\(\) expects null, mixed given.#'

--- a/src/ArrayData.php
+++ b/src/ArrayData.php
@@ -11,13 +11,15 @@ final class ArrayData
 {
     /**
      * Internal representation of data data.
+     * 
+     * @var array<mixed>
      */
     private array $data = [];
 
     /**
      * The constructor.
      *
-     * @param array $data The data
+     * @param array<mixed> $data The data
      */
     public function __construct(array $data = [])
     {
@@ -93,7 +95,7 @@ final class ArrayData
     /**
      * Get all values.
      *
-     * @return array The values
+     * @return array<mixed> The values
      */
     public function all(): array
     {

--- a/src/ArrayTransformer.php
+++ b/src/ArrayTransformer.php
@@ -51,7 +51,7 @@ final class ArrayTransformer implements TransformerInterface
      *
      * @param ArrayTransformer|null $transformer The parent transformer
      */
-    public function __construct(ArrayTransformer $transformer = null)
+    public function __construct(?ArrayTransformer $transformer = null)
     {
         $this->converter = new ArrayValueConverter();
 

--- a/src/ArrayTransformerFilterItem.php
+++ b/src/ArrayTransformerFilterItem.php
@@ -9,13 +9,16 @@ final class ArrayTransformerFilterItem
 {
     private string $name = '';
 
+    /**
+     * @var array<mixed>
+     */
     private array $arguments = [];
 
     /**
      * The constructor.
      *
      * @param string $name The filter to apply
-     * @param array $arguments The parameters for the filter
+     * @param array<mixed> $arguments The parameters for the filter
      */
     public function __construct(string $name, array $arguments = [])
     {
@@ -36,7 +39,7 @@ final class ArrayTransformerFilterItem
     /**
      * Get filter parameters.
      *
-     * @return array The params
+     * @return array<mixed> The params
      */
     public function getArguments(): array
     {

--- a/src/ArrayTransformerRule.php
+++ b/src/ArrayTransformerRule.php
@@ -32,7 +32,7 @@ final class ArrayTransformerRule
      *
      * @param ArrayTransformer|null $transformer The parent transformer
      */
-    public function __construct(ArrayTransformer $transformer = null)
+    public function __construct(?ArrayTransformer $transformer = null)
     {
         $this->transformer = $transformer ?? new ArrayTransformer();
     }
@@ -222,7 +222,7 @@ final class ArrayTransformerRule
      *
      * @return $this Self
      */
-    public function date(string $format = 'Y-m-d H:i:s', DateTimeZone $dateTimeZone = null): self
+    public function date(string $format = 'Y-m-d H:i:s', ?DateTimeZone $dateTimeZone = null): self
     {
         return $this->filter('date', $format, $dateTimeZone);
     }

--- a/src/Filter/DateTimeFilter.php
+++ b/src/Filter/DateTimeFilter.php
@@ -23,7 +23,7 @@ final class DateTimeFilter
      *
      * @return string The value
      */
-    public function __invoke($value, string $format = null, DateTimeZone $timezone = null)
+    public function __invoke($value, ?string $format = null, ?DateTimeZone $timezone = null)
     {
         try {
             $format = $format ?? 'Y-m-d H:i:s';
@@ -52,7 +52,7 @@ final class DateTimeFilter
     private function formatDateTime(
         DateTimeImmutable $value,
         string $format,
-        DateTimeZone $timezone = null
+        ?DateTimeZone $timezone = null
     ): string {
         if ($timezone) {
             // This would only with only work with UTC as default time zone.

--- a/src/Filter/TransformFilter.php
+++ b/src/Filter/TransformFilter.php
@@ -16,7 +16,7 @@ final class TransformFilter
      *
      * @param ArrayTransformer|null $transformer The parent transformer
      */
-    public function __construct(ArrayTransformer $transformer = null)
+    public function __construct(?ArrayTransformer $transformer = null)
     {
         $this->transformer = $transformer ?? new ArrayTransformer();
     }


### PR DESCRIPTION
Hello!

I'm getting the following error in the Transformer library when using PHP 8.4:

PHP Deprecated: Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead.

I’ve fixed the issue and took the liberty of making a few additional improvements—mainly just updating some files. I hope that’s okay.

Kind regards,
Heinrich Schiller